### PR TITLE
Add TypeScript Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,5 +76,8 @@ module.exports = fp(fastifySqlite, {
   fastify: '^4.x'
 })
 
+module.exports.default = fastifySqlite
+module.exports.fastifySqlite = fastifySqlite
+
 // let the user access the sqlite3 mode constants eg: sqlite3.OPEN_READONLY
 module.exports.sqlite3 = sqlite3

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "1.1.0",
   "description": "Fastify plugin to connect to a SQLite database",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap test/**/*.test.js"
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:typescript": "tsd",
+    "test:unit": "tap test/**/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -29,9 +32,12 @@
   },
   "homepage": "https://github.com/Eomm/fastify-sqlite#readme",
   "devDependencies": {
+    "@fastify/pre-commit": "^2.0.2",
+    "@types/node": "^18.0.0",
     "fastify": "^4.5.3",
     "standard": "^17.0.0",
-    "tap": "^16.3.0"
+    "tap": "^16.3.0",
+    "tsd": "^0.25.0"
   },
   "dependencies": {
     "fastify-plugin": "^4.2.1",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,50 @@
+import type { FastifyPluginAsync } from "fastify";
+import { sqlite3 } from "sqlite3";
+import { Database } from "sqlite";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    sqlite: Database & { [name: string]: Database };
+  }
+}
+
+type FastifySqlite = FastifyPluginAsync<fastifySqlite.FastifySqliteOptions>;
+
+declare namespace fastifySqlite {
+  export interface FastifySqliteOptions {
+    /**
+     * Enable Promise API
+     * @default false
+     */
+    promiseApi?: boolean;
+    /**
+     * Optional decorator name
+     * @default null
+     */
+    name?: string;
+    /**
+     * Log sqlite3 queries as trace
+     * @default false
+     */
+    verbose?: boolean;
+    /**
+     * Select the database file
+     * @default ':memory:'
+     */
+    dbFile?: string;
+    /**
+     * How to connect to the DB
+     * @default OPEN_READWRITE | OPEN_CREATE | OPEN_FULLMUTEX
+     */
+    mode?: number;
+  }
+
+  export const sqlite3: sqlite3;
+  export const fastifySqlite: FastifySqlite;
+  export { fastifySqlite as default };
+}
+
+declare function fastifySqlite(
+  ...params: Parameters<FastifySqlite>
+): ReturnType<FastifySqlite>;
+export = fastifySqlite;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,0 +1,20 @@
+import fastify from "fastify";
+import fastifySqlite, { sqlite3 as reExportedSqlite3 } from ".";
+import { expectType } from "tsd";
+import { sqlite3 } from "sqlite3";
+import { Database } from "sqlite";
+
+const app = fastify();
+
+app
+  .register(fastifySqlite, {
+    dbFile: "foo.db",
+    name: "foo",
+  })
+  .after((err) => {
+    app.sqlite;
+    expectType<Database & { [name: string]: Database }>(app.sqlite);
+    expectType<Database>(app.sqlite.foo);
+  });
+
+expectType<sqlite3>(reExportedSqlite3);


### PR DESCRIPTION
Add TypeScript Support.

Issues:
1. It use `Database` Interface from [sqlite](https://github.com/kriasoft/node-sqlite), so there will be some `undefined` method when `promiseApi: false`.
2. IntelliSense does not show description of `name` parameter option.


Reference: https://github.com/fastify/fastify-mongodb